### PR TITLE
Add setting to skip generation of runtime.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ heroku buildpacks:clear
 heroku buildpacks:add https://github.com/moneymeets/python-poetry-buildpack.git
 heroku buildpacks:add heroku/python
 ```
+
+Generation of the `runtime.txt` can be skipped by setting `DISABLE_POETRY_CREATE_RUNTIME_FILE` to `1`:
+
+```
+heroku config:set DISABLE_POETRY_CREATE_RUNTIME_FILE=1
+```

--- a/bin/compile
+++ b/bin/compile
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 export BUILD_DIR=$1
+export ENV_DIR=$3
 export POETRY_VERSION=1.0.10
+
+export DISABLE_POETRY_CREATE_RUNTIME_FILE="$(cat $ENV_DIR/DISABLE_POETRY_CREATE_RUNTIME_FILE 2>/dev/null || true)"
 
 function indent() {
         c='s/^/       /'
@@ -28,6 +31,11 @@ poetry export -f requirements.txt -o requirements.txt --without-hashes
 RUNTIME_FILE="runtime.txt"
 
 echo "-----> Export Python version from Poetry to Heroku $RUNTIME_FILE file"
+
+if [ "$DISABLE_POETRY_CREATE_RUNTIME_FILE" ] && [ "$DISABLE_POETRY_CREATE_RUNTIME_FILE" != "0" ]; then
+  echo "-----> Skipping generation of $RUNTIME_FILE file from poetry.lock"
+  exit 0
+fi
 
 if [ -f "$RUNTIME_FILE" ]; then
   echo "-----> $RUNTIME_FILE found, delete this file in your repository!"


### PR DESCRIPTION
It can be inconvenient to be forced to specify an exact Python version
in `pyproject.toml`. It requires local development to have that
precise Python version, which isn't too great for every
developer. This change adds the option to provide an existing runtime
file, and not throw an error during the buildpack. The setting is
`POETRY_CREATE_RUNTIME_FILE`.

Resolves: #6 