### PR TITLE
Added selection of poetry version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ Generation of the `runtime.txt` can be skipped by setting `DISABLE_POETRY_CREATE
 ```
 heroku config:set DISABLE_POETRY_CREATE_RUNTIME_FILE=1
 ```
+
+The Poetry version can be specified by setting `POETRY_VERSION` in Heroku config vars. Otherwise it will default to a hard coded version.
+
+```
+heroku config:set POETRY_VERSION=1.1.0
+```

--- a/bin/compile
+++ b/bin/compile
@@ -8,8 +8,8 @@ export DISABLE_POETRY_CREATE_RUNTIME_FILE="$(cat $ENV_DIR/DISABLE_POETRY_CREATE_
 
 if [ -z "$POETRY_VERSION" ];
 then
-    echo "-----> No Poetry version sepecified in POETRY_VERSION config var. Defaulting to 1.0.10"
     export POETRY_VERSION=1.0.10
+    echo "-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to $POETRY_VERSION."
 else
     echo "-----> Using Poetry version from POETRY_VERSION config var: $POETRY_VERSION"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -2,9 +2,17 @@
 
 export BUILD_DIR=$1
 export ENV_DIR=$3
-export POETRY_VERSION=1.0.10
+export POETRY_VERSION="$(cat $ENV_DIR/POETRY_VERSION 2>/dev/null)"
 
 export DISABLE_POETRY_CREATE_RUNTIME_FILE="$(cat $ENV_DIR/DISABLE_POETRY_CREATE_RUNTIME_FILE 2>/dev/null || true)"
+
+if [ -z "$POETRY_VERSION" ];
+then
+    echo "-----> No Poetry version sepecified in POETRY_VERSION config var. Defaulting to 1.0.10"
+    export POETRY_VERSION=1.0.10
+else
+    echo "-----> Using Poetry version from POETRY_VERSION config var: $POETRY_VERSION"
+fi
 
 function indent() {
         c='s/^/       /'


### PR DESCRIPTION
This allows the user to specify the poetry version to be used. If no `POETRY_VERSION` is specified we just default to the hard coded version as before.

Ran into a problem yesterday as I was already on Poetry 1.1.0 and had a v1.1.0 poetry.lock file while the buildpack still has version 1.0.10 specified. Naturally, poetry complained about it as:

```bash
The lock file might not be compatible with the current version of Poetry.
Upgrade Poetry to ensure the lock file is read properly or, alternatively, regenerate the lock file with the `poetry lock` command.
``` 

This should be more flexible now as the users can control the version on their own.