### PR TITLE
Transform dependencies for locked packages only

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -36,7 +36,8 @@ source $HOME/.poetry/env
 # ToDo: remove this hack when Poetry 1.1.3 is released. Fix in https://github.com/python-poetry/poetry/pull/3119
 if [ "$POETRY_VERSION" = "1.1.2" ]; then
   echo "-----> Patch Poetry export file"
-  sed -i '234s/deepcopy(requirement)/deepcopy(__get_locked_package(requirement).to_dependency())/' $HOME/.poetry/lib/poetry/packages/locker.py
+  REPLACE_STR="deepcopy(__get_locked_package(requirement).to_dependency()) if __get_locked_package(requirement) else deepcopy(requirement)"
+  sed -i "234s/deepcopy(requirement)/$REPLACE_STR/" $HOME/.poetry/lib/poetry/packages/locker.py
 fi
 
 echo "-----> Export requirements.txt from Poetry"


### PR DESCRIPTION
@zyv Ich habe befürchtet, dass soetwas passieren wird...
Fix für https://github.com/moneymeets/python-poetry-buildpack/issues/16