### PR TITLE
Strip out editable installs forcefully

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ echo "-----> Export requirements.txt from Poetry"
 cd "$BUILD_DIR"
 
 # pip can't handle editable dependencies when requiring hashes (https://github.com/pypa/pip/issues/4995)
-poetry export -f requirements.txt -o requirements.txt --without-hashes
+poetry export -f requirements.txt --without-hashes | sed 's/^-e //' > requirements.txt
 
 RUNTIME_FILE="runtime.txt"
 


### PR DESCRIPTION
Keeping editable installs in the resultant `requirements.txt` file can
cause issues when installing from local directories. This manifests as
a missing module error for `setuptools`.

This change pipes the output of poetry export through sed to remove
any "-e " prefixes.

This isn't the exact same issue, but adds a little context: https://github.com/python-poetry/poetry/issues/897