### PR TITLE
Allow Python version to be overridden

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -59,8 +59,10 @@ if [ -f "$RUNTIME_FILE" ]; then
   exit 1
 fi
 
-# Get Python version from poetry.lock file metadata section
-VERSION=$(sed -n '/^\[metadata\]/,/^\[/p' poetry.lock | sed -n -e 's/^python-versions\s*=\s*//p' | tr -d '\"')
+if [ ! -v "$PYTHON_VERSION" ]; then
+  # Get Python version from poetry.lock file metadata section
+  PYTHON_VERSION=$(sed -n '/^\[metadata\]/,/^\[/p' poetry.lock | sed -n -e 's/^python-versions\s*=\s*//p' | tr -d '\"')
+fi
 
 # Version is only valid if exact interpreter version is specified
 #
@@ -68,10 +70,10 @@ VERSION=$(sed -n '/^\[metadata\]/,/^\[/p' poetry.lock | sed -n -e 's/^python-ver
 # 3.8 -> not valid
 # 3.8.1 -> valid
 
-if [[ $VERSION =~ ^[2-9](\.[0-9]+){2}$ ]]; then
-  log "Write $VERSION into $RUNTIME_FILE"
-  echo "python-$VERSION" > $RUNTIME_FILE
+if [[ $PYTHON_VERSION =~ ^[2-9](\.[0-9]+){2}$ ]]; then
+  log "Write $PYTHON_VERSION into $RUNTIME_FILE"
+  echo "python-$PYTHON_VERSION" > $RUNTIME_FILE
 else
-  log "$VERSION is not valid, please specify an exact Python version (e.g. 3.8.1) in your pyproject.toml (and thus poetry.lock)"
+  log "$PYTHON_VERSION is not valid, please specify an exact Python version (e.g. 3.8.1) in your pyproject.toml (and thus poetry.lock)"
   exit 1
 fi


### PR DESCRIPTION
Some setups may involve a Poetry configuration that supports multiple versions of Python. This change allows the runtime Python version to be specified using the `PYTHON_VERSION` environment variable.