### PR TITLE
Add POETRY_INCLUDE_DEV_DEPENDENCIES config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ heroku buildpacks:add https://github.com/moneymeets/python-poetry-buildpack.git
 heroku buildpacks:add heroku/python
 ```
 
+Inclusion of dev-dependencies (such as for CI pipeline) can be optionally enabled by setting  `POETRY_INCLUDE_DEV_DEPENDENCIES` to `1`:
+
+```
+heroku config:set POETRY_INCLUDE_DEV_DEPENDENCIES=1
+```
+
+
 Generation of the `runtime.txt` can be skipped by setting `DISABLE_POETRY_CREATE_RUNTIME_FILE` to `1`:
 
 ```

--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,7 @@ function log() {
 export BUILD_DIR=$1
 export ENV_DIR=$3
 export POETRY_VERSION="$(cat $ENV_DIR/POETRY_VERSION 2>/dev/null)"
-
+export POETRY_INCLUDE_DEV_DEPENDENCIES="$(cat $ENV_DIR/POETRY_INCLUDE_DEV_DEPENDENCIES 2>/dev/null || false)"
 export DISABLE_POETRY_CREATE_RUNTIME_FILE="$(cat $ENV_DIR/DISABLE_POETRY_CREATE_RUNTIME_FILE 2>/dev/null || true)"
 
 if [ -z "$POETRY_VERSION" ];
@@ -43,7 +43,12 @@ cd "$BUILD_DIR"
 
 # pip can't handle vcs & editable dependencies when requiring hashes (https://github.com/pypa/pip/issues/4995)
 # poetry exports local dependencies as editable by default (https://github.com/python-poetry/poetry/issues/897)
-poetry export -f requirements.txt --without-hashes --with-credentials | sed 's/^-e //' > requirements.txt
+if [ "$POETRY_INCLUDE_DEV_DEPENDENCIES" ] && [ "$POETRY_INCLUDE_DEV_DEPENDENCIES" != "0" ]; 
+then
+  poetry export -f requirements.txt --without-hashes --with-credentials --dev | sed 's/^-e //' > requirements.txt
+else
+  poetry export -f requirements.txt --without-hashes --with-credentials | sed 's/^-e //' > requirements.txt
+fi
 
 RUNTIME_FILE="runtime.txt"
 


### PR DESCRIPTION
A typical build pipeline may have four or more environments:
- local (dev)
- CI (Heroku)
- review (Heroku)
- production (Heroku)

The CI environment requires dev dependencies, whereas the review and production environments do not.  

This update allows the user to set a configuration variable so that the environment variables can specify whether or not to include dev dependencies.