### PR TITLE
Replace deprecated poetry installer

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -36,7 +36,7 @@ log "Generate requirements.txt with Poetry"
 
 log "Install Poetry"
 
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py \
+curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py \
     | sed -e 's/allowed_executables = \["python", "python3"\]/allowed_executables = ["python3"]/' \
     | python3 \
     | indent


### PR DESCRIPTION
The previous get-poetry.py installer is now deprecated.
[Said on official poetry website](https://python-poetry.org/docs/master/#installing-with-the-official-installer)