### PR TITLE
Use new Poetry installer and default to 1.2.0

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -40,6 +40,9 @@ curl -sSL https://install.python-poetry.org \
     | sed -e 's/allowed_executables = \["python", "python3"\]/allowed_executables = ["python3"]/' \
     | python3 \
     | indent
+    
+echo 'Adding poetry to the $PATH'
+export PATH="/app/.local/bin:$PATH"
 
 PATH_TO_POETRY_ENV="$HOME/.poetry/env"
 

--- a/bin/compile
+++ b/bin/compile
@@ -44,13 +44,6 @@ curl -sSL https://install.python-poetry.org \
 echo 'Adding poetry to the $PATH'
 export PATH="/app/.local/bin:$PATH"
 
-# PATH_TO_POETRY_ENV="$HOME/.poetry/env"
-
-# if [ -f "$PATH_TO_POETRY_ENV" ] ; then
-#     # shellcheck source=/dev/null
-#     . "$PATH_TO_POETRY_ENV"
-# fi
-
 REQUIREMENTS_FILE="requirements.txt"
 
 log "Export $REQUIREMENTS_FILE from Poetry"

--- a/bin/compile
+++ b/bin/compile
@@ -57,6 +57,8 @@ if [ "${POETRY_EXPORT_DEV_REQUIREMENTS:-0}" != "0" ] ; then
     EXPORT_PARAMETERS+=(--dev)
 fi
 
+# Allow `poetry export` to work even if we aren't using the
+# Python version that the project will ultimately run in
 poetry config virtualenvs.prefer-active-python true
 
 # pip can't handle vcs & editable dependencies when requiring hashes (https://github.com/pypa/pip/issues/4995)

--- a/bin/compile
+++ b/bin/compile
@@ -41,7 +41,7 @@ curl -sSL https://install.python-poetry.org \
     | python3 \
     | indent
     
-echo 'Adding poetry to the $PATH'
+log 'Adding poetry to the $PATH'
 export PATH="/app/.local/bin:$PATH"
 
 REQUIREMENTS_FILE="requirements.txt"

--- a/bin/compile
+++ b/bin/compile
@@ -57,9 +57,11 @@ if [ "${POETRY_EXPORT_DEV_REQUIREMENTS:-0}" != "0" ] ; then
     EXPORT_PARAMETERS+=(--dev)
 fi
 
-# Allow `poetry export` to work even if we aren't using the
-# Python version that the project will ultimately run in
-poetry config virtualenvs.prefer-active-python true
+if [ "${POETRY_VERSION:0:3}" = "1.2" ] ; then
+    # Allow `poetry export` to work even if we aren't using the
+    # Python version that the project will ultimately run in
+    poetry config virtualenvs.prefer-active-python true
+fi
 
 # pip can't handle vcs & editable dependencies when requiring hashes (https://github.com/pypa/pip/issues/4995)
 # poetry exports local dependencies as editable by default (https://github.com/python-poetry/poetry/issues/897)

--- a/bin/compile
+++ b/bin/compile
@@ -40,7 +40,7 @@ curl -sSL https://install.python-poetry.org \
     | sed -e 's/allowed_executables = \["python", "python3"\]/allowed_executables = ["python3"]/' \
     | python3 \
     | indent
-    
+
 log "Adding poetry to the PATH"
 export PATH="/app/.local/bin:$PATH"
 
@@ -56,6 +56,8 @@ if [ "${POETRY_EXPORT_DEV_REQUIREMENTS:-0}" != "0" ] ; then
     log "Enable exporting dev requirements to $REQUIREMENTS_FILE"
     EXPORT_PARAMETERS+=(--dev)
 fi
+
+poetry config virtualenvs.prefer-active-python true
 
 # pip can't handle vcs & editable dependencies when requiring hashes (https://github.com/pypa/pip/issues/4995)
 # poetry exports local dependencies as editable by default (https://github.com/python-poetry/poetry/issues/897)

--- a/bin/compile
+++ b/bin/compile
@@ -41,7 +41,7 @@ curl -sSL https://install.python-poetry.org \
     | python3 \
     | indent
     
-log 'Adding poetry to the $PATH'
+log "Adding poetry to the PATH"
 export PATH="/app/.local/bin:$PATH"
 
 REQUIREMENTS_FILE="requirements.txt"

--- a/bin/compile
+++ b/bin/compile
@@ -36,7 +36,7 @@ log "Generate requirements.txt with Poetry"
 
 log "Install Poetry"
 
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py \
+curl -sSL https://install.python-poetry.org \
     | sed -e 's/allowed_executables = \["python", "python3"\]/allowed_executables = ["python3"]/' \
     | python3 \
     | indent

--- a/bin/compile
+++ b/bin/compile
@@ -57,7 +57,7 @@ log "Export $REQUIREMENTS_FILE from Poetry"
 
 cd "$BUILD_DIR"
 
-EXPORT_PARAMETERS=(--without-hashes --with-credentials --quiet)
+EXPORT_PARAMETERS=(--without-hashes --with-credentials)
 
 if [ "${POETRY_EXPORT_DEV_REQUIREMENTS:-0}" != "0" ] ; then
     log "Enable exporting dev requirements to $REQUIREMENTS_FILE"
@@ -66,10 +66,8 @@ fi
 
 # pip can't handle vcs & editable dependencies when requiring hashes (https://github.com/pypa/pip/issues/4995)
 # poetry exports local dependencies as editable by default (https://github.com/python-poetry/poetry/issues/897)
-poetry export -f "$REQUIREMENTS_FILE" "${EXPORT_PARAMETERS[@]}" > "$REQUIREMENTS_FILE.orig"
+poetry export -f requirements.txt "${EXPORT_PARAMETERS[@]}" -o "$REQUIREMENTS_FILE.orig"
 sed -e 's/^-e //' < "$REQUIREMENTS_FILE.orig" > "$REQUIREMENTS_FILE" && rm "$REQUIREMENTS_FILE.orig"
-
-cat "$REQUIREMENTS_FILE"
 
 RUNTIME_FILE="runtime.txt"
 

--- a/bin/compile
+++ b/bin/compile
@@ -44,12 +44,12 @@ curl -sSL https://install.python-poetry.org \
 echo 'Adding poetry to the $PATH'
 export PATH="/app/.local/bin:$PATH"
 
-PATH_TO_POETRY_ENV="$HOME/.poetry/env"
+# PATH_TO_POETRY_ENV="$HOME/.poetry/env"
 
-if [ -f "$PATH_TO_POETRY_ENV" ] ; then
-    # shellcheck source=/dev/null
-    . "$PATH_TO_POETRY_ENV"
-fi
+# if [ -f "$PATH_TO_POETRY_ENV" ] ; then
+#     # shellcheck source=/dev/null
+#     . "$PATH_TO_POETRY_ENV"
+# fi
 
 REQUIREMENTS_FILE="requirements.txt"
 
@@ -68,6 +68,8 @@ fi
 # poetry exports local dependencies as editable by default (https://github.com/python-poetry/poetry/issues/897)
 poetry export -f "$REQUIREMENTS_FILE" "${EXPORT_PARAMETERS[@]}" > "$REQUIREMENTS_FILE.orig"
 sed -e 's/^-e //' < "$REQUIREMENTS_FILE.orig" > "$REQUIREMENTS_FILE" && rm "$REQUIREMENTS_FILE.orig"
+
+cat "$REQUIREMENTS_FILE"
 
 RUNTIME_FILE="runtime.txt"
 

--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ for env_file in $BUILDPACK_VARIABLES ; do
 done
 
 if [ -z "${POETRY_VERSION:-}" ] ; then
-    export POETRY_VERSION=1.1.13
+    export POETRY_VERSION=1.2.0
     log "No Poetry version specified in POETRY_VERSION config var. Defaulting to $POETRY_VERSION."
 else
     log "Using Poetry version from POETRY_VERSION config var: $POETRY_VERSION"

--- a/bin/compile
+++ b/bin/compile
@@ -60,6 +60,7 @@ fi
 if [ "${POETRY_VERSION:0:3}" = "1.2" ] ; then
     # Allow `poetry export` to work even if we aren't using the
     # Python version that the project will ultimately run in
+    log "Set virtualenvs.prefer-active-python to true"
     poetry config virtualenvs.prefer-active-python true
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -57,7 +57,7 @@ log "Export $REQUIREMENTS_FILE from Poetry"
 
 cd "$BUILD_DIR"
 
-EXPORT_PARAMETERS=(--without-hashes --with-credentials)
+EXPORT_PARAMETERS=(--without-hashes --with-credentials --quiet)
 
 if [ "${POETRY_EXPORT_DEV_REQUIREMENTS:-0}" != "0" ] ; then
     log "Enable exporting dev requirements to $REQUIREMENTS_FILE"

--- a/bin/compile
+++ b/bin/compile
@@ -41,8 +41,15 @@ curl -sSL https://install.python-poetry.org \
     | python3 \
     | indent
 
-log "Adding poetry to the PATH"
+log "Add poetry to the PATH"
 export PATH="/app/.local/bin:$PATH"
+
+if [ "${POETRY_VERSION:0:3}" = "1.2" ] ; then
+    # Allow `poetry export` to work even if we aren't using the
+    # Python version that the project will ultimately run in
+    log "Set virtualenvs.prefer-active-python to true"
+    poetry config virtualenvs.prefer-active-python true | indent
+fi
 
 REQUIREMENTS_FILE="requirements.txt"
 
@@ -57,16 +64,9 @@ if [ "${POETRY_EXPORT_DEV_REQUIREMENTS:-0}" != "0" ] ; then
     EXPORT_PARAMETERS+=(--dev)
 fi
 
-if [ "${POETRY_VERSION:0:3}" = "1.2" ] ; then
-    # Allow `poetry export` to work even if we aren't using the
-    # Python version that the project will ultimately run in
-    log "Set virtualenvs.prefer-active-python to true"
-    poetry config virtualenvs.prefer-active-python true
-fi
-
 # pip can't handle vcs & editable dependencies when requiring hashes (https://github.com/pypa/pip/issues/4995)
 # poetry exports local dependencies as editable by default (https://github.com/python-poetry/poetry/issues/897)
-poetry export -f requirements.txt "${EXPORT_PARAMETERS[@]}" -o "$REQUIREMENTS_FILE.orig"
+poetry export -f requirements.txt "${EXPORT_PARAMETERS[@]}" -o "$REQUIREMENTS_FILE.orig" | indent
 sed -e 's/^-e //' < "$REQUIREMENTS_FILE.orig" > "$REQUIREMENTS_FILE" && rm "$REQUIREMENTS_FILE.orig"
 
 RUNTIME_FILE="runtime.txt"

--- a/bin/compile
+++ b/bin/compile
@@ -49,6 +49,7 @@ if [ "${POETRY_VERSION:0:3}" = "1.2" ] ; then
     # Python version that the project will ultimately run in
     log "Set virtualenvs.prefer-active-python to true"
     poetry config virtualenvs.prefer-active-python true | indent
+    poetry config virtualenvs.create false | indent
 fi
 
 REQUIREMENTS_FILE="requirements.txt"

--- a/test/fixtures/compile-export_dev.stdout.txt
+++ b/test/fixtures/compile-export_dev.stdout.txt
@@ -1,9 +1,13 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.13.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.2.0.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Add poetry to the PATH
+-----> Set virtualenvs.prefer-active-python to true
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
 -----> Enable exporting dev requirements to requirements.txt
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Read Python version from poetry.lock
 -----> Write 3.8.3 into runtime.txt

--- a/test/fixtures/compile-force_poetry_version.stdout.txt
+++ b/test/fixtures/compile-force_poetry_version.stdout.txt
@@ -2,6 +2,10 @@
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Add poetry to the PATH
+-----> Set virtualenvs.prefer-active-python to true
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Skip generation of runtime.txt file from poetry.lock

--- a/test/fixtures/compile-force_python_version.stdout.txt
+++ b/test/fixtures/compile-force_python_version.stdout.txt
@@ -1,8 +1,12 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.13.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.2.0.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Add poetry to the PATH
+-----> Set virtualenvs.prefer-active-python to true
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Force Python version to 3.4.5, because PYTHON_RUNTIME_VERSION is set!
 -----> Write 3.4.5 into runtime.txt

--- a/test/fixtures/compile-invalid_python_version.stdout.txt
+++ b/test/fixtures/compile-invalid_python_version.stdout.txt
@@ -1,7 +1,11 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.13.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.2.0.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Add poetry to the PATH
+-----> Set virtualenvs.prefer-active-python to true
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Read Python version from poetry.lock

--- a/test/fixtures/compile-no_vars_success.stdout.txt
+++ b/test/fixtures/compile-no_vars_success.stdout.txt
@@ -1,8 +1,12 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.13.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.2.0.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Add poetry to the PATH
+-----> Set virtualenvs.prefer-active-python to true
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Read Python version from poetry.lock
 -----> Write 3.8.3 into runtime.txt

--- a/test/fixtures/compile-skip_runtime_error.stdout.txt
+++ b/test/fixtures/compile-skip_runtime_error.stdout.txt
@@ -1,6 +1,10 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.13.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.2.0.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Add poetry to the PATH
+-----> Set virtualenvs.prefer-active-python to true
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file

--- a/test/fixtures/compile-skip_runtime_success.stdout.txt
+++ b/test/fixtures/compile-skip_runtime_success.stdout.txt
@@ -1,7 +1,11 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.1.13.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.2.0.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<
+-----> Add poetry to the PATH
+-----> Set virtualenvs.prefer-active-python to true
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
+       >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Skip generation of runtime.txt file from poetry.lock

--- a/test/utils
+++ b/test/utils
@@ -58,6 +58,10 @@ function curl() {
 export -f curl
 
 function poetry() {
+    if [ "$1" = "export" ] ; then
+        # Fake creating the export file
+        touch requirements.txt.orig
+    fi
     echo ">>> mocked poetry call <<<"
 }
 

--- a/test/utils
+++ b/test/utils
@@ -59,8 +59,9 @@ export -f curl
 
 function poetry() {
     if [ "$1" = "export" ] ; then
-        # Fake creating the export file
-        touch requirements.txt.orig
+        # mock creating the export file
+        last="$#"
+        touch "${!last}"
     fi
     echo ">>> mocked poetry call <<<"
 }


### PR DESCRIPTION
The current (old) installer is totally broken, as far as I can tell. I don't think passing `GET_POETRY_IGNORE_DEPRECATION` works because it starts with `GET_`?

```
-----> Install Poetry
       Retrieving Poetry metadata
       
       This installer is deprecated, and cannot install Poetry 1.2.0a1 or newer.
       Additionally, Poetry installations created by this installer cannot `self update` to 1.2.0a1 or later.
       You should migrate to https://install.python-poetry.org instead. Instructions are available at https://python-poetry.org/docs/#installation.
       
       This installer will now exit. If you understand the above warning and wish to proceed anyway, set GET_POETRY_IGNORE_DEPRECATION=1 in the environment and run this installer again.
```

I see #39 which mentions some errors, but I didn't get any here. Maybe those have been fixed since then?