### PR TITLE
ci(actions): bump checkout action from v2 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run linter
         run: |


### PR DESCRIPTION
* actions/checkout@v3 is using Node 16, this will fix the warning in https://github.com/moneymeets/python-poetry-buildpack/actions/runs/3459523142