### PR TITLE
fix(compile): make POETRY_EXPORT_PARAMS compatible with POETRY_EXPORT…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,11 @@ Exporting of development dependencies (e.g. to run tests in CI pipelines) can be
 heroku config:set POETRY_EXPORT_DEV_REQUIREMENTS=1
 ```
 
-If you want to provide your own options with export instead of using the defaults (`--without-hashes --with-credentials`), you can set `POETRY_EXPORT_PARAMS` to your choice. This way you could set `--with-hashes` if you don't use git dependencies for example. This option will also skip any value set to `POETRY_EXPORT_DEV_REQUIREMENTS` config var.
+If you want to override the default export parameters (`--without-hashes --with-credentials`), you can set the `POETRY_EXPORT_PARAMS` config var. For example, you can use `--with-hashes` for added security, if you don't need git dependencies. This option is compatible with `POETRY_EXPORT_DEV_REQUIREMENTS` config var documented above.
 
 ```
 heroku config:set POETRY_EXPORT_PARAMS=--with-hashes
 ```
-
 
 ### runtime.txt
 

--- a/bin/compile
+++ b/bin/compile
@@ -56,17 +56,14 @@ cd "$BUILD_DIR"
 
 EXPORT_PARAMETERS=(--without-hashes --with-credentials)
 
-# if POETRY_EXPORT_PARAMS config var is set, override default (--without-hashes --with-credentials) export option
-# if POETRY_EXPORT_PARAMS config var is set, it will also skip POETRY_EXPORT_DEV_REQUIREMENTS config var
 if [ "${POETRY_EXPORT_PARAMS:-0}" != "0" ] ; then
-    log "Using POETRY_EXPORT_PARAMS config var ($POETRY_EXPORT_PARAMS) as export option for $REQUIREMENTS_FILE"
-    EXPORT_PARAMETERS=( "$POETRY_EXPORT_PARAMS" )
-else
-    # if POETRY_EXPORT_PARAMS config var is not set, check POETRY_EXPORT_DEV_REQUIREMENTS config var
-    if [ "${POETRY_EXPORT_DEV_REQUIREMENTS:-0}" != "0" ] ; then
-        log "Enable exporting dev requirements to $REQUIREMENTS_FILE"
-        EXPORT_PARAMETERS+=(--dev)
-    fi
+    IFS=" " read -r -a EXPORT_PARAMETERS <<< "$POETRY_EXPORT_PARAMS"
+    log "Using POETRY_EXPORT_PARAMS to set export params (" "${EXPORT_PARAMETERS[@]}" ") for $REQUIREMENTS_FILE"
+fi
+
+if [ "${POETRY_EXPORT_DEV_REQUIREMENTS:-0}" != "0" ] ; then
+    log "Enable exporting dev requirements to $REQUIREMENTS_FILE"
+    EXPORT_PARAMETERS+=(--dev)
 fi
 
 # pip can't handle vcs & editable dependencies when requiring hashes (https://github.com/pypa/pip/issues/4995)

--- a/test/fixtures/compile-export_params-0.stdout.txt
+++ b/test/fixtures/compile-export_params-0.stdout.txt
@@ -7,7 +7,7 @@
        >>> mocked poetry call <<<
        >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
------> Using POETRY_EXPORT_PARAMS config var (--with test) as export option for requirements.txt
+-----> Using POETRY_EXPORT_PARAMS to set export params ( --with test ) for requirements.txt
        >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Read Python version from poetry.lock

--- a/test/fixtures/compile-export_params-1.stdout.txt
+++ b/test/fixtures/compile-export_params-1.stdout.txt
@@ -7,7 +7,8 @@
        >>> mocked poetry call <<<
        >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
------> Using POETRY_EXPORT_PARAMS config var (--with test) as export option for requirements.txt
+-----> Using POETRY_EXPORT_PARAMS to set export params ( --with test ) for requirements.txt
+-----> Enable exporting dev requirements to requirements.txt
        >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file
 -----> Read Python version from poetry.lock


### PR DESCRIPTION
Caused by #50.

Unfortunately, I've only now had a chance to look at the PR. I observed that you incorrectly initialized Bash array for `EXPORT_PARAMETERS`. If you do it the right way, then there is no need to make the two options incompatible. My suggestion is in the PR.

/cc @mohebmithani @ulgens