### PR TITLE
chore(poetry): update to Poetry 1.5.1 from 1.4.1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -26,7 +26,7 @@ for env_file in $BUILDPACK_VARIABLES ; do
 done
 
 if [ -z "${POETRY_VERSION:-}" ] ; then
-    export POETRY_VERSION=1.4.1
+    export POETRY_VERSION=1.5.1
     log "No Poetry version specified in POETRY_VERSION config var. Defaulting to $POETRY_VERSION."
 else
     log "Using Poetry version from POETRY_VERSION config var: $POETRY_VERSION"

--- a/test/fixtures/compile-exact_version_specifier.stdout.txt
+++ b/test/fixtures/compile-exact_version_specifier.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.4.1.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.5.1.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-export_dev.stdout.txt
+++ b/test/fixtures/compile-export_dev.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.4.1.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.5.1.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-export_params-0.stdout.txt
+++ b/test/fixtures/compile-export_params-0.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.4.1.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.5.1.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-export_params-1.stdout.txt
+++ b/test/fixtures/compile-export_params-1.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.4.1.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.5.1.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-force_python_version.stdout.txt
+++ b/test/fixtures/compile-force_python_version.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.4.1.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.5.1.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-invalid_python_version.stdout.txt
+++ b/test/fixtures/compile-invalid_python_version.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.4.1.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.5.1.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-no_vars_success.stdout.txt
+++ b/test/fixtures/compile-no_vars_success.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.4.1.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.5.1.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-skip_runtime_error.stdout.txt
+++ b/test/fixtures/compile-skip_runtime_error.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.4.1.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.5.1.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-skip_runtime_success.stdout.txt
+++ b/test/fixtures/compile-skip_runtime_success.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.4.1.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.5.1.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<

--- a/test/fixtures/compile-trailing_space.stdout.txt
+++ b/test/fixtures/compile-trailing_space.stdout.txt
@@ -1,4 +1,4 @@
------> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.4.1.
+-----> No Poetry version specified in POETRY_VERSION config var. Defaulting to 1.5.1.
 -----> Generate requirements.txt with Poetry
 -----> Install Poetry
        >>> mocked curl call <<<


### PR DESCRIPTION
Bumped to latest Poetry version 1.5.1 (https://github.com/python-poetry/poetry/releases/tag/1.5.1).
The old lockfile is compatible.