### PR TITLE
feat(compile): install poetry export plugin explicitly

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -58,6 +58,10 @@ if [ "${POETRY_VERSION:0:3}" = "1.2" ] ; then
     poetry config virtualenvs.create false | indent
 fi
 
+# Plugin is needs to be installed explicitly in future versions of Poetry
+log "Install poetry-plugin-export"
+poetry self add poetry-plugin-export | indent
+
 REQUIREMENTS_FILE="requirements.txt"
 
 log "Export $REQUIREMENTS_FILE from Poetry"

--- a/test/fixtures/compile-exact_version_specifier.stdout.txt
+++ b/test/fixtures/compile-exact_version_specifier.stdout.txt
@@ -3,6 +3,8 @@
 -----> Install Poetry
        >>> mocked curl call <<<
 -----> Add Poetry to the PATH
+-----> Install poetry-plugin-export
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
        >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file

--- a/test/fixtures/compile-export_dev.stdout.txt
+++ b/test/fixtures/compile-export_dev.stdout.txt
@@ -3,6 +3,8 @@
 -----> Install Poetry
        >>> mocked curl call <<<
 -----> Add Poetry to the PATH
+-----> Install poetry-plugin-export
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
 -----> Enable exporting dev requirements to requirements.txt
        >>> mocked poetry call <<<

--- a/test/fixtures/compile-export_params-0.stdout.txt
+++ b/test/fixtures/compile-export_params-0.stdout.txt
@@ -3,6 +3,8 @@
 -----> Install Poetry
        >>> mocked curl call <<<
 -----> Add Poetry to the PATH
+-----> Install poetry-plugin-export
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
 -----> Using POETRY_EXPORT_PARAMS to set export params ( --with test ) for requirements.txt
        >>> mocked poetry call <<<

--- a/test/fixtures/compile-export_params-1.stdout.txt
+++ b/test/fixtures/compile-export_params-1.stdout.txt
@@ -3,6 +3,8 @@
 -----> Install Poetry
        >>> mocked curl call <<<
 -----> Add Poetry to the PATH
+-----> Install poetry-plugin-export
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
 -----> Using POETRY_EXPORT_PARAMS to set export params ( --with test ) for requirements.txt
 -----> Enable exporting dev requirements to requirements.txt

--- a/test/fixtures/compile-force_poetry_version.stdout.txt
+++ b/test/fixtures/compile-force_poetry_version.stdout.txt
@@ -6,6 +6,8 @@
 -----> Force usage of active Python and disable creation of virtualenvs
        >>> mocked poetry call <<<
        >>> mocked poetry call <<<
+-----> Install poetry-plugin-export
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
        >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file

--- a/test/fixtures/compile-force_python_version.stdout.txt
+++ b/test/fixtures/compile-force_python_version.stdout.txt
@@ -3,6 +3,8 @@
 -----> Install Poetry
        >>> mocked curl call <<<
 -----> Add Poetry to the PATH
+-----> Install poetry-plugin-export
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
        >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file

--- a/test/fixtures/compile-invalid_python_version.stdout.txt
+++ b/test/fixtures/compile-invalid_python_version.stdout.txt
@@ -3,6 +3,8 @@
 -----> Install Poetry
        >>> mocked curl call <<<
 -----> Add Poetry to the PATH
+-----> Install poetry-plugin-export
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
        >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file

--- a/test/fixtures/compile-no_vars_success.stdout.txt
+++ b/test/fixtures/compile-no_vars_success.stdout.txt
@@ -3,6 +3,8 @@
 -----> Install Poetry
        >>> mocked curl call <<<
 -----> Add Poetry to the PATH
+-----> Install poetry-plugin-export
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
        >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file

--- a/test/fixtures/compile-poetry_version_comment.stdout.txt
+++ b/test/fixtures/compile-poetry_version_comment.stdout.txt
@@ -3,6 +3,8 @@
 -----> Install Poetry
        >>> mocked curl call <<<
 -----> Add Poetry to the PATH
+-----> Install poetry-plugin-export
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
        >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file

--- a/test/fixtures/compile-skip_runtime_error.stdout.txt
+++ b/test/fixtures/compile-skip_runtime_error.stdout.txt
@@ -3,6 +3,8 @@
 -----> Install Poetry
        >>> mocked curl call <<<
 -----> Add Poetry to the PATH
+-----> Install poetry-plugin-export
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
        >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file

--- a/test/fixtures/compile-skip_runtime_success.stdout.txt
+++ b/test/fixtures/compile-skip_runtime_success.stdout.txt
@@ -3,6 +3,8 @@
 -----> Install Poetry
        >>> mocked curl call <<<
 -----> Add Poetry to the PATH
+-----> Install poetry-plugin-export
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
        >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file

--- a/test/fixtures/compile-trailing_space.stdout.txt
+++ b/test/fixtures/compile-trailing_space.stdout.txt
@@ -3,6 +3,8 @@
 -----> Install Poetry
        >>> mocked curl call <<<
 -----> Add Poetry to the PATH
+-----> Install poetry-plugin-export
+       >>> mocked poetry call <<<
 -----> Export requirements.txt from Poetry
        >>> mocked poetry call <<<
 -----> Export Python version from Poetry to Heroku runtime.txt file


### PR DESCRIPTION
Required in future versions of Poetry, see https://python-poetry.org/blog/announcing-poetry-1.7.0/#removing-poetry-plugin-export-from-the-default-installation.