### PR TITLE
fix(compile): fix compatibility with older versions of poetry (#67)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -58,9 +58,9 @@ if [ "${POETRY_VERSION:0:3}" = "1.2" ] ; then
     poetry config virtualenvs.create false | indent
 fi
 
-# Plugin is needs to be installed explicitly in future versions of Poetry
+# Plugin needs to be installed explicitly in future versions of Poetry
 log "Install poetry-plugin-export"
-poetry self add poetry-plugin-export | indent
+poetry self add 'poetry-plugin-export@*' | indent
 
 REQUIREMENTS_FILE="requirements.txt"
 


### PR DESCRIPTION
Proposed fix for #67. One could consider adding single quotes like `'poetry-plugin-export@*'` to prevent any potential accidental shell interpretation.