### PR TITLE
Disable export plugin warning

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -62,6 +62,12 @@ fi
 log "Install poetry-plugin-export"
 poetry self add 'poetry-plugin-export@*' | indent
 
+# Disabled warning about manually installing export plugin
+# https://python-poetry.org/blog/announcing-poetry-1.8.0/#removing-poetry-plugin-export-from-the-default-installation
+if [ "${POETRY_VERSION:0:3}" = "1.8" ] ; then
+    poetry config warnings.export false
+fi
+
 REQUIREMENTS_FILE="requirements.txt"
 
 log "Export $REQUIREMENTS_FILE from Poetry"


### PR DESCRIPTION
Disables the `Warning: poetry-plugin-export will not be installed by default in a future version of Poetry.` warning, as the plugin is installed.

For details see https://github.com/moneymeets/python-poetry-buildpack/issues/70

Added a version check as the warning only shows from `1.8` onwards, also might be necessary to stop silencing the warning in a future version.