### PR TITLE
Warn that the buildpack is deprecated + no longer required

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A [Heroku](https://devcenter.heroku.com/) Buildpack for [Poetry](https://github.com/python-poetry/poetry) users.
 
+> [!WARNING]
+> The Heroku Python buildpack [now supports Poetry itself](https://github.com/heroku/heroku-buildpack-python/pull/1682), and so an additional Poetry
+> buildpack is no longer required to deploy an app that uses Poetry to Heroku.
+>
+> As such, this buildpack is deprecated and you should no longer use it.
+
 ## How to use
 
 The Python Poetry Buildpack prepares the build to be processed by a Python buildpack such as `heroku/python` by generating `requirements.txt` and `runtime.txt` from `poetry.lock`. With that said, your repo cannot have a `requirements.txt`, it will be exported from Poetry (for `runtime.txt` see below).

--- a/bin/compile
+++ b/bin/compile
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+export BUILD_DIR="$1"
+export ENV_DIR="$3"
+
 function log() {
     echo "-----> $*"
 }
@@ -10,8 +13,48 @@ function indent() {
     sed -e 's/^/       /'
 }
 
-export BUILD_DIR="$1"
-export ENV_DIR="$3"
+function warning() {
+    local ansi_yellow='\033[1;33m'
+    local ansi_reset='\033[0m'
+    echo >&2
+    while IFS= read -r line; do
+        echo -e "${ansi_yellow} !     ${line}${ansi_reset}" >&2
+    done
+    echo >&2
+}
+
+warning <<-'EOF'
+Warning: This buildpack is no longer required!
+
+The Heroku Python buildpack now supports Poetry itself,
+and so an additional Poetry buildpack is no longer
+required to deploy an app that uses Poetry to Heroku.
+
+We recommend migrating away from this buildpack, since:
+- It is deprecated and no longer being maintained.
+- The native Poetry support installs dependencies using
+  Poetry directly, rather than by exporting them to a
+  requirements.txt file for use with pip. It also caches
+  the Poetry install for faster rebuilds.
+
+To migrate:
+1. Run 'heroku buildpacks' to find the exact URL/alias
+   configured on your app for the Poetry buildpack.
+2. Remove the Poetry buildpack using:
+   'heroku buildpacks:remove <BUILDPACK_URL>'
+   For example:
+   'heroku buildpacks:remove https://github.com/moneymeets/python-poetry-buildpack.git'
+3. Create a '.python-version' file in the root of your
+   repository containing a Python version that matches
+   the version listed in your 'poetry.lock' under
+   'metadata.python-versions'. For syntax, see:
+   https://devcenter.heroku.com/articles/python-runtimes
+4. Commit all changes and deploy your app as normal.
+
+For more information, see:
+https://github.com/moneymeets/python-poetry-buildpack/issues/75
+https://github.com/heroku/heroku-buildpack-python/pull/1682
+EOF
 
 BUILDPACK_VARIABLES="DISABLE_POETRY_CREATE_RUNTIME_FILE PYTHON_RUNTIME_VERSION"
 

--- a/test/fixtures/compile-exact_version_specifier.stderr.txt
+++ b/test/fixtures/compile-exact_version_specifier.stderr.txt
@@ -1,0 +1,32 @@
+
+[1;33m !     Warning: This buildpack is no longer required![0m
+[1;33m !     [0m
+[1;33m !     The Heroku Python buildpack now supports Poetry itself,[0m
+[1;33m !     and so an additional Poetry buildpack is no longer[0m
+[1;33m !     required to deploy an app that uses Poetry to Heroku.[0m
+[1;33m !     [0m
+[1;33m !     We recommend migrating away from this buildpack, since:[0m
+[1;33m !     - It is deprecated and no longer being maintained.[0m
+[1;33m !     - The native Poetry support installs dependencies using[0m
+[1;33m !       Poetry directly, rather than by exporting them to a[0m
+[1;33m !       requirements.txt file for use with pip. It also caches[0m
+[1;33m !       the Poetry install for faster rebuilds.[0m
+[1;33m !     [0m
+[1;33m !     To migrate:[0m
+[1;33m !     1. Run 'heroku buildpacks' to find the exact URL/alias[0m
+[1;33m !        configured on your app for the Poetry buildpack.[0m
+[1;33m !     2. Remove the Poetry buildpack using:[0m
+[1;33m !        'heroku buildpacks:remove <BUILDPACK_URL>'[0m
+[1;33m !        For example:[0m
+[1;33m !        'heroku buildpacks:remove https://github.com/moneymeets/python-poetry-buildpack.git'[0m
+[1;33m !     3. Create a '.python-version' file in the root of your[0m
+[1;33m !        repository containing a Python version that matches[0m
+[1;33m !        the version listed in your 'poetry.lock' under[0m
+[1;33m !        'metadata.python-versions'. For syntax, see:[0m
+[1;33m !        https://devcenter.heroku.com/articles/python-runtimes[0m
+[1;33m !     4. Commit all changes and deploy your app as normal.[0m
+[1;33m !     [0m
+[1;33m !     For more information, see:[0m
+[1;33m !     https://github.com/moneymeets/python-poetry-buildpack/issues/75[0m
+[1;33m !     https://github.com/heroku/heroku-buildpack-python/pull/1682[0m
+

--- a/test/fixtures/compile-export_dev.stderr.txt
+++ b/test/fixtures/compile-export_dev.stderr.txt
@@ -1,0 +1,32 @@
+
+[1;33m !     Warning: This buildpack is no longer required![0m
+[1;33m !     [0m
+[1;33m !     The Heroku Python buildpack now supports Poetry itself,[0m
+[1;33m !     and so an additional Poetry buildpack is no longer[0m
+[1;33m !     required to deploy an app that uses Poetry to Heroku.[0m
+[1;33m !     [0m
+[1;33m !     We recommend migrating away from this buildpack, since:[0m
+[1;33m !     - It is deprecated and no longer being maintained.[0m
+[1;33m !     - The native Poetry support installs dependencies using[0m
+[1;33m !       Poetry directly, rather than by exporting them to a[0m
+[1;33m !       requirements.txt file for use with pip. It also caches[0m
+[1;33m !       the Poetry install for faster rebuilds.[0m
+[1;33m !     [0m
+[1;33m !     To migrate:[0m
+[1;33m !     1. Run 'heroku buildpacks' to find the exact URL/alias[0m
+[1;33m !        configured on your app for the Poetry buildpack.[0m
+[1;33m !     2. Remove the Poetry buildpack using:[0m
+[1;33m !        'heroku buildpacks:remove <BUILDPACK_URL>'[0m
+[1;33m !        For example:[0m
+[1;33m !        'heroku buildpacks:remove https://github.com/moneymeets/python-poetry-buildpack.git'[0m
+[1;33m !     3. Create a '.python-version' file in the root of your[0m
+[1;33m !        repository containing a Python version that matches[0m
+[1;33m !        the version listed in your 'poetry.lock' under[0m
+[1;33m !        'metadata.python-versions'. For syntax, see:[0m
+[1;33m !        https://devcenter.heroku.com/articles/python-runtimes[0m
+[1;33m !     4. Commit all changes and deploy your app as normal.[0m
+[1;33m !     [0m
+[1;33m !     For more information, see:[0m
+[1;33m !     https://github.com/moneymeets/python-poetry-buildpack/issues/75[0m
+[1;33m !     https://github.com/heroku/heroku-buildpack-python/pull/1682[0m
+

--- a/test/fixtures/compile-export_params-0.stderr.txt
+++ b/test/fixtures/compile-export_params-0.stderr.txt
@@ -1,0 +1,32 @@
+
+[1;33m !     Warning: This buildpack is no longer required![0m
+[1;33m !     [0m
+[1;33m !     The Heroku Python buildpack now supports Poetry itself,[0m
+[1;33m !     and so an additional Poetry buildpack is no longer[0m
+[1;33m !     required to deploy an app that uses Poetry to Heroku.[0m
+[1;33m !     [0m
+[1;33m !     We recommend migrating away from this buildpack, since:[0m
+[1;33m !     - It is deprecated and no longer being maintained.[0m
+[1;33m !     - The native Poetry support installs dependencies using[0m
+[1;33m !       Poetry directly, rather than by exporting them to a[0m
+[1;33m !       requirements.txt file for use with pip. It also caches[0m
+[1;33m !       the Poetry install for faster rebuilds.[0m
+[1;33m !     [0m
+[1;33m !     To migrate:[0m
+[1;33m !     1. Run 'heroku buildpacks' to find the exact URL/alias[0m
+[1;33m !        configured on your app for the Poetry buildpack.[0m
+[1;33m !     2. Remove the Poetry buildpack using:[0m
+[1;33m !        'heroku buildpacks:remove <BUILDPACK_URL>'[0m
+[1;33m !        For example:[0m
+[1;33m !        'heroku buildpacks:remove https://github.com/moneymeets/python-poetry-buildpack.git'[0m
+[1;33m !     3. Create a '.python-version' file in the root of your[0m
+[1;33m !        repository containing a Python version that matches[0m
+[1;33m !        the version listed in your 'poetry.lock' under[0m
+[1;33m !        'metadata.python-versions'. For syntax, see:[0m
+[1;33m !        https://devcenter.heroku.com/articles/python-runtimes[0m
+[1;33m !     4. Commit all changes and deploy your app as normal.[0m
+[1;33m !     [0m
+[1;33m !     For more information, see:[0m
+[1;33m !     https://github.com/moneymeets/python-poetry-buildpack/issues/75[0m
+[1;33m !     https://github.com/heroku/heroku-buildpack-python/pull/1682[0m
+

--- a/test/fixtures/compile-export_params-1.stderr.txt
+++ b/test/fixtures/compile-export_params-1.stderr.txt
@@ -1,0 +1,32 @@
+
+[1;33m !     Warning: This buildpack is no longer required![0m
+[1;33m !     [0m
+[1;33m !     The Heroku Python buildpack now supports Poetry itself,[0m
+[1;33m !     and so an additional Poetry buildpack is no longer[0m
+[1;33m !     required to deploy an app that uses Poetry to Heroku.[0m
+[1;33m !     [0m
+[1;33m !     We recommend migrating away from this buildpack, since:[0m
+[1;33m !     - It is deprecated and no longer being maintained.[0m
+[1;33m !     - The native Poetry support installs dependencies using[0m
+[1;33m !       Poetry directly, rather than by exporting them to a[0m
+[1;33m !       requirements.txt file for use with pip. It also caches[0m
+[1;33m !       the Poetry install for faster rebuilds.[0m
+[1;33m !     [0m
+[1;33m !     To migrate:[0m
+[1;33m !     1. Run 'heroku buildpacks' to find the exact URL/alias[0m
+[1;33m !        configured on your app for the Poetry buildpack.[0m
+[1;33m !     2. Remove the Poetry buildpack using:[0m
+[1;33m !        'heroku buildpacks:remove <BUILDPACK_URL>'[0m
+[1;33m !        For example:[0m
+[1;33m !        'heroku buildpacks:remove https://github.com/moneymeets/python-poetry-buildpack.git'[0m
+[1;33m !     3. Create a '.python-version' file in the root of your[0m
+[1;33m !        repository containing a Python version that matches[0m
+[1;33m !        the version listed in your 'poetry.lock' under[0m
+[1;33m !        'metadata.python-versions'. For syntax, see:[0m
+[1;33m !        https://devcenter.heroku.com/articles/python-runtimes[0m
+[1;33m !     4. Commit all changes and deploy your app as normal.[0m
+[1;33m !     [0m
+[1;33m !     For more information, see:[0m
+[1;33m !     https://github.com/moneymeets/python-poetry-buildpack/issues/75[0m
+[1;33m !     https://github.com/heroku/heroku-buildpack-python/pull/1682[0m
+

--- a/test/fixtures/compile-force_poetry_version.stderr.txt
+++ b/test/fixtures/compile-force_poetry_version.stderr.txt
@@ -1,0 +1,32 @@
+
+[1;33m !     Warning: This buildpack is no longer required![0m
+[1;33m !     [0m
+[1;33m !     The Heroku Python buildpack now supports Poetry itself,[0m
+[1;33m !     and so an additional Poetry buildpack is no longer[0m
+[1;33m !     required to deploy an app that uses Poetry to Heroku.[0m
+[1;33m !     [0m
+[1;33m !     We recommend migrating away from this buildpack, since:[0m
+[1;33m !     - It is deprecated and no longer being maintained.[0m
+[1;33m !     - The native Poetry support installs dependencies using[0m
+[1;33m !       Poetry directly, rather than by exporting them to a[0m
+[1;33m !       requirements.txt file for use with pip. It also caches[0m
+[1;33m !       the Poetry install for faster rebuilds.[0m
+[1;33m !     [0m
+[1;33m !     To migrate:[0m
+[1;33m !     1. Run 'heroku buildpacks' to find the exact URL/alias[0m
+[1;33m !        configured on your app for the Poetry buildpack.[0m
+[1;33m !     2. Remove the Poetry buildpack using:[0m
+[1;33m !        'heroku buildpacks:remove <BUILDPACK_URL>'[0m
+[1;33m !        For example:[0m
+[1;33m !        'heroku buildpacks:remove https://github.com/moneymeets/python-poetry-buildpack.git'[0m
+[1;33m !     3. Create a '.python-version' file in the root of your[0m
+[1;33m !        repository containing a Python version that matches[0m
+[1;33m !        the version listed in your 'poetry.lock' under[0m
+[1;33m !        'metadata.python-versions'. For syntax, see:[0m
+[1;33m !        https://devcenter.heroku.com/articles/python-runtimes[0m
+[1;33m !     4. Commit all changes and deploy your app as normal.[0m
+[1;33m !     [0m
+[1;33m !     For more information, see:[0m
+[1;33m !     https://github.com/moneymeets/python-poetry-buildpack/issues/75[0m
+[1;33m !     https://github.com/heroku/heroku-buildpack-python/pull/1682[0m
+

--- a/test/fixtures/compile-force_python_version.stderr.txt
+++ b/test/fixtures/compile-force_python_version.stderr.txt
@@ -1,0 +1,32 @@
+
+[1;33m !     Warning: This buildpack is no longer required![0m
+[1;33m !     [0m
+[1;33m !     The Heroku Python buildpack now supports Poetry itself,[0m
+[1;33m !     and so an additional Poetry buildpack is no longer[0m
+[1;33m !     required to deploy an app that uses Poetry to Heroku.[0m
+[1;33m !     [0m
+[1;33m !     We recommend migrating away from this buildpack, since:[0m
+[1;33m !     - It is deprecated and no longer being maintained.[0m
+[1;33m !     - The native Poetry support installs dependencies using[0m
+[1;33m !       Poetry directly, rather than by exporting them to a[0m
+[1;33m !       requirements.txt file for use with pip. It also caches[0m
+[1;33m !       the Poetry install for faster rebuilds.[0m
+[1;33m !     [0m
+[1;33m !     To migrate:[0m
+[1;33m !     1. Run 'heroku buildpacks' to find the exact URL/alias[0m
+[1;33m !        configured on your app for the Poetry buildpack.[0m
+[1;33m !     2. Remove the Poetry buildpack using:[0m
+[1;33m !        'heroku buildpacks:remove <BUILDPACK_URL>'[0m
+[1;33m !        For example:[0m
+[1;33m !        'heroku buildpacks:remove https://github.com/moneymeets/python-poetry-buildpack.git'[0m
+[1;33m !     3. Create a '.python-version' file in the root of your[0m
+[1;33m !        repository containing a Python version that matches[0m
+[1;33m !        the version listed in your 'poetry.lock' under[0m
+[1;33m !        'metadata.python-versions'. For syntax, see:[0m
+[1;33m !        https://devcenter.heroku.com/articles/python-runtimes[0m
+[1;33m !     4. Commit all changes and deploy your app as normal.[0m
+[1;33m !     [0m
+[1;33m !     For more information, see:[0m
+[1;33m !     https://github.com/moneymeets/python-poetry-buildpack/issues/75[0m
+[1;33m !     https://github.com/heroku/heroku-buildpack-python/pull/1682[0m
+

--- a/test/fixtures/compile-invalid_python_version.stderr.txt
+++ b/test/fixtures/compile-invalid_python_version.stderr.txt
@@ -1,1 +1,33 @@
+
+[1;33m !     Warning: This buildpack is no longer required![0m
+[1;33m !     [0m
+[1;33m !     The Heroku Python buildpack now supports Poetry itself,[0m
+[1;33m !     and so an additional Poetry buildpack is no longer[0m
+[1;33m !     required to deploy an app that uses Poetry to Heroku.[0m
+[1;33m !     [0m
+[1;33m !     We recommend migrating away from this buildpack, since:[0m
+[1;33m !     - It is deprecated and no longer being maintained.[0m
+[1;33m !     - The native Poetry support installs dependencies using[0m
+[1;33m !       Poetry directly, rather than by exporting them to a[0m
+[1;33m !       requirements.txt file for use with pip. It also caches[0m
+[1;33m !       the Poetry install for faster rebuilds.[0m
+[1;33m !     [0m
+[1;33m !     To migrate:[0m
+[1;33m !     1. Run 'heroku buildpacks' to find the exact URL/alias[0m
+[1;33m !        configured on your app for the Poetry buildpack.[0m
+[1;33m !     2. Remove the Poetry buildpack using:[0m
+[1;33m !        'heroku buildpacks:remove <BUILDPACK_URL>'[0m
+[1;33m !        For example:[0m
+[1;33m !        'heroku buildpacks:remove https://github.com/moneymeets/python-poetry-buildpack.git'[0m
+[1;33m !     3. Create a '.python-version' file in the root of your[0m
+[1;33m !        repository containing a Python version that matches[0m
+[1;33m !        the version listed in your 'poetry.lock' under[0m
+[1;33m !        'metadata.python-versions'. For syntax, see:[0m
+[1;33m !        https://devcenter.heroku.com/articles/python-runtimes[0m
+[1;33m !     4. Commit all changes and deploy your app as normal.[0m
+[1;33m !     [0m
+[1;33m !     For more information, see:[0m
+[1;33m !     https://github.com/moneymeets/python-poetry-buildpack/issues/75[0m
+[1;33m !     https://github.com/heroku/heroku-buildpack-python/pull/1682[0m
+
 -----> ^3.8 is not valid, please specify an exact Python version (e.g. 3.8.1 or ==3.8.1) in your pyproject.toml (and thus poetry.lock)

--- a/test/fixtures/compile-no_vars_success.stderr.txt
+++ b/test/fixtures/compile-no_vars_success.stderr.txt
@@ -1,0 +1,32 @@
+
+[1;33m !     Warning: This buildpack is no longer required![0m
+[1;33m !     [0m
+[1;33m !     The Heroku Python buildpack now supports Poetry itself,[0m
+[1;33m !     and so an additional Poetry buildpack is no longer[0m
+[1;33m !     required to deploy an app that uses Poetry to Heroku.[0m
+[1;33m !     [0m
+[1;33m !     We recommend migrating away from this buildpack, since:[0m
+[1;33m !     - It is deprecated and no longer being maintained.[0m
+[1;33m !     - The native Poetry support installs dependencies using[0m
+[1;33m !       Poetry directly, rather than by exporting them to a[0m
+[1;33m !       requirements.txt file for use with pip. It also caches[0m
+[1;33m !       the Poetry install for faster rebuilds.[0m
+[1;33m !     [0m
+[1;33m !     To migrate:[0m
+[1;33m !     1. Run 'heroku buildpacks' to find the exact URL/alias[0m
+[1;33m !        configured on your app for the Poetry buildpack.[0m
+[1;33m !     2. Remove the Poetry buildpack using:[0m
+[1;33m !        'heroku buildpacks:remove <BUILDPACK_URL>'[0m
+[1;33m !        For example:[0m
+[1;33m !        'heroku buildpacks:remove https://github.com/moneymeets/python-poetry-buildpack.git'[0m
+[1;33m !     3. Create a '.python-version' file in the root of your[0m
+[1;33m !        repository containing a Python version that matches[0m
+[1;33m !        the version listed in your 'poetry.lock' under[0m
+[1;33m !        'metadata.python-versions'. For syntax, see:[0m
+[1;33m !        https://devcenter.heroku.com/articles/python-runtimes[0m
+[1;33m !     4. Commit all changes and deploy your app as normal.[0m
+[1;33m !     [0m
+[1;33m !     For more information, see:[0m
+[1;33m !     https://github.com/moneymeets/python-poetry-buildpack/issues/75[0m
+[1;33m !     https://github.com/heroku/heroku-buildpack-python/pull/1682[0m
+

--- a/test/fixtures/compile-poetry_version_comment.stderr.txt
+++ b/test/fixtures/compile-poetry_version_comment.stderr.txt
@@ -1,0 +1,32 @@
+
+[1;33m !     Warning: This buildpack is no longer required![0m
+[1;33m !     [0m
+[1;33m !     The Heroku Python buildpack now supports Poetry itself,[0m
+[1;33m !     and so an additional Poetry buildpack is no longer[0m
+[1;33m !     required to deploy an app that uses Poetry to Heroku.[0m
+[1;33m !     [0m
+[1;33m !     We recommend migrating away from this buildpack, since:[0m
+[1;33m !     - It is deprecated and no longer being maintained.[0m
+[1;33m !     - The native Poetry support installs dependencies using[0m
+[1;33m !       Poetry directly, rather than by exporting them to a[0m
+[1;33m !       requirements.txt file for use with pip. It also caches[0m
+[1;33m !       the Poetry install for faster rebuilds.[0m
+[1;33m !     [0m
+[1;33m !     To migrate:[0m
+[1;33m !     1. Run 'heroku buildpacks' to find the exact URL/alias[0m
+[1;33m !        configured on your app for the Poetry buildpack.[0m
+[1;33m !     2. Remove the Poetry buildpack using:[0m
+[1;33m !        'heroku buildpacks:remove <BUILDPACK_URL>'[0m
+[1;33m !        For example:[0m
+[1;33m !        'heroku buildpacks:remove https://github.com/moneymeets/python-poetry-buildpack.git'[0m
+[1;33m !     3. Create a '.python-version' file in the root of your[0m
+[1;33m !        repository containing a Python version that matches[0m
+[1;33m !        the version listed in your 'poetry.lock' under[0m
+[1;33m !        'metadata.python-versions'. For syntax, see:[0m
+[1;33m !        https://devcenter.heroku.com/articles/python-runtimes[0m
+[1;33m !     4. Commit all changes and deploy your app as normal.[0m
+[1;33m !     [0m
+[1;33m !     For more information, see:[0m
+[1;33m !     https://github.com/moneymeets/python-poetry-buildpack/issues/75[0m
+[1;33m !     https://github.com/heroku/heroku-buildpack-python/pull/1682[0m
+

--- a/test/fixtures/compile-sanity-1.stderr.txt
+++ b/test/fixtures/compile-sanity-1.stderr.txt
@@ -1,1 +1,1 @@
-../bin/compile: line 13: $1: unbound variable
+../bin/compile: line 5: $1: unbound variable

--- a/test/fixtures/compile-sanity-2.stderr.txt
+++ b/test/fixtures/compile-sanity-2.stderr.txt
@@ -1,1 +1,1 @@
-../bin/compile: line 14: $3: unbound variable
+../bin/compile: line 6: $3: unbound variable

--- a/test/fixtures/compile-skip_runtime_error.stderr.txt
+++ b/test/fixtures/compile-skip_runtime_error.stderr.txt
@@ -1,1 +1,33 @@
+
+[1;33m !     Warning: This buildpack is no longer required![0m
+[1;33m !     [0m
+[1;33m !     The Heroku Python buildpack now supports Poetry itself,[0m
+[1;33m !     and so an additional Poetry buildpack is no longer[0m
+[1;33m !     required to deploy an app that uses Poetry to Heroku.[0m
+[1;33m !     [0m
+[1;33m !     We recommend migrating away from this buildpack, since:[0m
+[1;33m !     - It is deprecated and no longer being maintained.[0m
+[1;33m !     - The native Poetry support installs dependencies using[0m
+[1;33m !       Poetry directly, rather than by exporting them to a[0m
+[1;33m !       requirements.txt file for use with pip. It also caches[0m
+[1;33m !       the Poetry install for faster rebuilds.[0m
+[1;33m !     [0m
+[1;33m !     To migrate:[0m
+[1;33m !     1. Run 'heroku buildpacks' to find the exact URL/alias[0m
+[1;33m !        configured on your app for the Poetry buildpack.[0m
+[1;33m !     2. Remove the Poetry buildpack using:[0m
+[1;33m !        'heroku buildpacks:remove <BUILDPACK_URL>'[0m
+[1;33m !        For example:[0m
+[1;33m !        'heroku buildpacks:remove https://github.com/moneymeets/python-poetry-buildpack.git'[0m
+[1;33m !     3. Create a '.python-version' file in the root of your[0m
+[1;33m !        repository containing a Python version that matches[0m
+[1;33m !        the version listed in your 'poetry.lock' under[0m
+[1;33m !        'metadata.python-versions'. For syntax, see:[0m
+[1;33m !        https://devcenter.heroku.com/articles/python-runtimes[0m
+[1;33m !     4. Commit all changes and deploy your app as normal.[0m
+[1;33m !     [0m
+[1;33m !     For more information, see:[0m
+[1;33m !     https://github.com/moneymeets/python-poetry-buildpack/issues/75[0m
+[1;33m !     https://github.com/heroku/heroku-buildpack-python/pull/1682[0m
+
 -----> runtime.txt found, delete this file from your repository!

--- a/test/fixtures/compile-skip_runtime_success.stderr.txt
+++ b/test/fixtures/compile-skip_runtime_success.stderr.txt
@@ -1,0 +1,32 @@
+
+[1;33m !     Warning: This buildpack is no longer required![0m
+[1;33m !     [0m
+[1;33m !     The Heroku Python buildpack now supports Poetry itself,[0m
+[1;33m !     and so an additional Poetry buildpack is no longer[0m
+[1;33m !     required to deploy an app that uses Poetry to Heroku.[0m
+[1;33m !     [0m
+[1;33m !     We recommend migrating away from this buildpack, since:[0m
+[1;33m !     - It is deprecated and no longer being maintained.[0m
+[1;33m !     - The native Poetry support installs dependencies using[0m
+[1;33m !       Poetry directly, rather than by exporting them to a[0m
+[1;33m !       requirements.txt file for use with pip. It also caches[0m
+[1;33m !       the Poetry install for faster rebuilds.[0m
+[1;33m !     [0m
+[1;33m !     To migrate:[0m
+[1;33m !     1. Run 'heroku buildpacks' to find the exact URL/alias[0m
+[1;33m !        configured on your app for the Poetry buildpack.[0m
+[1;33m !     2. Remove the Poetry buildpack using:[0m
+[1;33m !        'heroku buildpacks:remove <BUILDPACK_URL>'[0m
+[1;33m !        For example:[0m
+[1;33m !        'heroku buildpacks:remove https://github.com/moneymeets/python-poetry-buildpack.git'[0m
+[1;33m !     3. Create a '.python-version' file in the root of your[0m
+[1;33m !        repository containing a Python version that matches[0m
+[1;33m !        the version listed in your 'poetry.lock' under[0m
+[1;33m !        'metadata.python-versions'. For syntax, see:[0m
+[1;33m !        https://devcenter.heroku.com/articles/python-runtimes[0m
+[1;33m !     4. Commit all changes and deploy your app as normal.[0m
+[1;33m !     [0m
+[1;33m !     For more information, see:[0m
+[1;33m !     https://github.com/moneymeets/python-poetry-buildpack/issues/75[0m
+[1;33m !     https://github.com/heroku/heroku-buildpack-python/pull/1682[0m
+

--- a/test/fixtures/compile-trailing_space.stderr.txt
+++ b/test/fixtures/compile-trailing_space.stderr.txt
@@ -1,0 +1,32 @@
+
+[1;33m !     Warning: This buildpack is no longer required![0m
+[1;33m !     [0m
+[1;33m !     The Heroku Python buildpack now supports Poetry itself,[0m
+[1;33m !     and so an additional Poetry buildpack is no longer[0m
+[1;33m !     required to deploy an app that uses Poetry to Heroku.[0m
+[1;33m !     [0m
+[1;33m !     We recommend migrating away from this buildpack, since:[0m
+[1;33m !     - It is deprecated and no longer being maintained.[0m
+[1;33m !     - The native Poetry support installs dependencies using[0m
+[1;33m !       Poetry directly, rather than by exporting them to a[0m
+[1;33m !       requirements.txt file for use with pip. It also caches[0m
+[1;33m !       the Poetry install for faster rebuilds.[0m
+[1;33m !     [0m
+[1;33m !     To migrate:[0m
+[1;33m !     1. Run 'heroku buildpacks' to find the exact URL/alias[0m
+[1;33m !        configured on your app for the Poetry buildpack.[0m
+[1;33m !     2. Remove the Poetry buildpack using:[0m
+[1;33m !        'heroku buildpacks:remove <BUILDPACK_URL>'[0m
+[1;33m !        For example:[0m
+[1;33m !        'heroku buildpacks:remove https://github.com/moneymeets/python-poetry-buildpack.git'[0m
+[1;33m !     3. Create a '.python-version' file in the root of your[0m
+[1;33m !        repository containing a Python version that matches[0m
+[1;33m !        the version listed in your 'poetry.lock' under[0m
+[1;33m !        'metadata.python-versions'. For syntax, see:[0m
+[1;33m !        https://devcenter.heroku.com/articles/python-runtimes[0m
+[1;33m !     4. Commit all changes and deploy your app as normal.[0m
+[1;33m !     [0m
+[1;33m !     For more information, see:[0m
+[1;33m !     https://github.com/moneymeets/python-poetry-buildpack/issues/75[0m
+[1;33m !     https://github.com/heroku/heroku-buildpack-python/pull/1682[0m
+


### PR DESCRIPTION
This buildpack is no longer required now that the Heroku Python buildpack supports Poetry natively:
- https://devcenter.heroku.com/changelog-items/3050
- https://github.com/heroku/heroku-buildpack-python/pull/1682

As such, a deprecation warning has been added to both the build log and the README.

The warning borrows from the implementation here (which uses colour, and also makes sure to ANSI wrap each line individually to prevent issues with streaming logs from `git push` etc):
https://github.com/heroku/heroku-buildpack-python/blob/ca99c39f9e3627fff727788206f7fcc4ff064b7f/lib/output.sh#L50-L66

Closes #75.